### PR TITLE
API-4400: changed validation for invalid / unknown query parameters, …

### DIFF
--- a/app/uk/gov/hmrc/pushpullnotificationsapi/controllers/TopicsController.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/controllers/TopicsController.scala
@@ -23,15 +23,13 @@ import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
-import uk.gov.hmrc.pushpullnotificationsapi.config.AppConfig
 import uk.gov.hmrc.pushpullnotificationsapi.controllers.actionbuilders.ValidateUserAgentHeaderAction
-import uk.gov.hmrc.pushpullnotificationsapi.models._
 import uk.gov.hmrc.pushpullnotificationsapi.models.RequestFormatters._
 import uk.gov.hmrc.pushpullnotificationsapi.models.ResponseFormatters._
+import uk.gov.hmrc.pushpullnotificationsapi.models._
 import uk.gov.hmrc.pushpullnotificationsapi.services.TopicsService
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 @Singleton()
@@ -83,21 +81,15 @@ class TopicsController @Inject()(validateUserAgentHeaderAction: ValidateUserAgen
       }
   }
 
-
   override protected def withJsonBody[T]
   (f: T => Future[Result])(implicit request: Request[JsValue], m: Manifest[T], reads: Reads[T]): Future[Result]
-
-  = {
-    withJson(request.body)(f)
-  }
+  = {withJson(request.body)(f)}
 
   private def withJson[T](json: JsValue)(f: T => Future[Result])(implicit reads: Reads[T]): Future[Result] = {
-    Try(json.validate[T]) match {
-      case Success(JsSuccess(payload, _)) => f(payload)
-      case Success(JsError(errs)) =>
+    json.validate[T] match {
+      case JsSuccess(payload, _) => f(payload)
+      case JsError(errs) =>
         Future.successful(BadRequest(JsErrorResponse(ErrorCode.INVALID_REQUEST_PAYLOAD, JsError.toJson(errs))))
-      case Failure(e) =>
-        Future.successful(BadRequest(JsErrorResponse(ErrorCode.INVALID_REQUEST_PAYLOAD, e.getMessage)))
     }
   }
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/controllers/actionbuilders/AuthAction.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/controllers/actionbuilders/AuthAction.scala
@@ -38,11 +38,11 @@ class AuthAction @Inject()(override val authConnector: AuthConnector)(implicit e
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
 
     authorised().retrieve(uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.clientId) {
-      case maybeClientId: Option[String]  => maybeClientId match {
-        case Some(clientId) =>  Future.successful(Right(AuthenticatedNotificationRequest[A](ClientId(clientId), request)))
-        case _ => Future.successful(Left(Unauthorized(JsErrorResponse(ErrorCode.UNAUTHORISED, "Unable to retrieve ClientId"))))
-      }
-      case _ => Future.successful(Left(Unauthorized(JsErrorResponse(ErrorCode.UNAUTHORISED, "Authorisation failed"))))
+      maybeClientId: Option[String] =>
+        maybeClientId match {
+          case Some(clientId) => Future.successful(Right(AuthenticatedNotificationRequest[A](ClientId(clientId), request)))
+          case _ => Future.successful(Left(Unauthorized(JsErrorResponse(ErrorCode.UNAUTHORISED, "Unable to retrieve ClientId"))))
+        }
     } recover {
       case e: AuthorisationException =>Left(Unauthorized(JsErrorResponse(ErrorCode.UNAUTHORISED, e.getMessage)))
     }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/models/jsonformatters.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/models/jsonformatters.scala
@@ -56,6 +56,7 @@ object ResponseFormatters{
   implicit val topicsFormats: OFormat[Topic] = Json.format[Topic]
   implicit val notificationFormatter: OFormat[Notification] = Json.format[Notification]
   implicit val createTopicResponseFormatter: OFormat[CreateTopicResponse] = Json.format[CreateTopicResponse]
+  implicit val createNotificationResponseFormatter: OFormat[CreateNotificationResponse] = Json.format[CreateNotificationResponse]
 }
 
 object RequestFormatters {

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/models/notifications/Notifications.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/models/notifications/Notifications.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.pushpullnotificationsapi.models.notifications
 
 import java.util.UUID
 
+import enumeratum.values.{StringEnum, StringEnumEntry, StringPlayJsonValueEnum}
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json.{Format, Json, OFormat}
@@ -28,17 +29,13 @@ import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.NotificationSta
 import scala.collection.immutable
 
 
-sealed trait NotificationContentType extends EnumEntry
+sealed abstract class MessageContentType(val value: String) extends StringEnumEntry
 
-object NotificationContentType extends Enum[NotificationContentType] with PlayJsonEnum[NotificationContentType] {
-  val values: immutable.IndexedSeq[NotificationContentType] = findValues
+object MessageContentType extends StringEnum[MessageContentType] with StringPlayJsonValueEnum[MessageContentType] {
+  val values: immutable.IndexedSeq[MessageContentType] = findValues
 
-  case object APPLICATION_JSON extends NotificationContentType
-
-  case object APPLICATION_XML extends NotificationContentType
-
-  case object UNSUPPORTED extends NotificationContentType
-
+  case object APPLICATION_JSON extends MessageContentType("application/json")
+  case object APPLICATION_XML extends MessageContentType("application/xml")
 }
 
 sealed trait NotificationStatus extends EnumEntry
@@ -47,11 +44,7 @@ object NotificationStatus extends Enum[NotificationStatus] with PlayJsonEnum[Not
   val values: immutable.IndexedSeq[NotificationStatus] = findValues
 
   case object RECEIVED extends NotificationStatus
-
   case object READ extends NotificationStatus
-
-  case object UNKNOWN extends NotificationStatus
-
 }
 
 
@@ -62,7 +55,7 @@ case class NotificationId(value: UUID) extends AnyVal {
 
 case class Notification(notificationId: NotificationId,
                         topicId: TopicId,
-                        notificationContentType: NotificationContentType,
+                        messageContentType: MessageContentType,
                         message: String,
                         status: NotificationStatus = RECEIVED,
                         createdDateTime: DateTime = DateTime.now(DateTimeZone.UTC),
@@ -71,7 +64,7 @@ case class Notification(notificationId: NotificationId,
 
 object Notification {
   implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
-  implicit val formatTopicID = Json.format[TopicId]
-  implicit val formatNotificationID = Json.format[NotificationId]
+  implicit val formatTopicID: OFormat[TopicId] = Json.format[TopicId]
+  implicit val formatNotificationID: OFormat[NotificationId] = Json.format[NotificationId]
   implicit val format: OFormat[Notification] = Json.format[Notification]
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/models/responses.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/models/responses.scala
@@ -20,6 +20,7 @@ import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.{JsObject, Json}
 
 case class CreateTopicResponse(topicId: String)
+case class CreateNotificationResponse(notificationId: String)
 
 object ErrorCode extends Enumeration {
   type ErrorCode = Value

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/models/results.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/models/results.scala
@@ -24,14 +24,25 @@ sealed trait TopicCreateSuccessResult extends TopicCreateResult
 final case class TopicCreatedResult(topicId: TopicId) extends TopicCreateSuccessResult
 final case class TopicRetrievedResult(topicId: TopicId) extends TopicCreateSuccessResult
 
-sealed trait NotificationServiceResult
-abstract class NotificationsServiceFailedResult() extends NotificationServiceResult
-abstract class NotificationsServiceSuccessResult() extends NotificationServiceResult
+sealed trait NotificationCreateServiceResult
 
-case class NotificationsServiceTopicNotFoundResult(message: String) extends NotificationsServiceFailedResult
-case class NotificationsServiceUnauthorisedResult(message: String) extends NotificationsServiceFailedResult
+sealed trait NotificationCreateServiceFailedResult extends NotificationCreateServiceResult
+sealed trait NotificationCreateServiceSuccessResult extends NotificationCreateServiceResult
 
-case class GetNotificationsSuccessRetrievedResult(notifications: List[Notification]) extends NotificationsServiceSuccessResult
+final case class NotificationCreateSuccessResult() extends NotificationCreateServiceSuccessResult
+final case class NotificationCreateFailedDuplicateResult(message: String) extends NotificationCreateServiceFailedResult
+final case class NotificationCreateFailedTopicNotFoundResult(message: String) extends NotificationCreateServiceFailedResult
 
-case class SaveNotificationFailedDuplicateNotificationResult(message: String) extends NotificationsServiceFailedResult
-case class SaveNotificationSuccessResult() extends NotificationsServiceSuccessResult
+sealed trait GetNotificationCreateServiceResult
+
+sealed trait GetNotificationsServiceFailedResult extends GetNotificationCreateServiceResult
+sealed trait GetNotificationsServiceSuccessResult extends GetNotificationCreateServiceResult
+
+
+final case class GetNotificationsServiceTopicNotFoundResult(message: String) extends GetNotificationsServiceFailedResult
+final case class GetNotificationsServiceUnauthorisedResult(message: String) extends GetNotificationsServiceFailedResult
+
+final case class GetNotificationsSuccessRetrievedResult(notifications: List[Notification]) extends GetNotificationsServiceSuccessResult
+
+
+

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/NotificationsRepository.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/NotificationsRepository.scala
@@ -92,6 +92,7 @@ class NotificationsRepository @Inject()(mongoComponent: ReactiveMongoComponent)
                      (implicit ec: ExecutionContext): Future[List[Notification]] = getByTopicIdAndFilters(topicId)
 
   def saveNotification(notification: Notification)(implicit ec: ExecutionContext): Future[Option[NotificationId]] =
+
     insert(notification).map(_ => Some(notification.notificationId)).recoverWith {
       case e: WriteResult if e.code.contains(MongoErrorCodes.DuplicateKey) =>
         Future.successful(None)

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/TopicsRepository.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/TopicsRepository.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.pushpullnotificationsapi.repository
 
-import java.util.UUID
-
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import play.api.Logger

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val scoverageSettings = {
   Seq(
     // Semicolon-separated list of regexs matching classes to exclude
     ScoverageKeys.coverageExcludedPackages := """uk\.gov\.hmrc\.BuildInfo;.*\.Routes;.*\.RoutesPrefix;.*Filters?;MicroserviceAuditConnector;Module;GraphiteStartUp;.*\.Reverse[^.]*""",
-    ScoverageKeys.coverageMinimum := 96,
+    ScoverageKeys.coverageMinimum := 99.8,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     parallelExecution in Test := false

--- a/it/uk/gov/hmrc/pushpullnotificationsapi/repository/NotificationRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/pushpullnotificationsapi/repository/NotificationRepositoryISpec.scala
@@ -8,7 +8,7 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.pushpullnotificationsapi.models._
-import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.NotificationContentType.APPLICATION_JSON
+import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.MessageContentType.APPLICATION_JSON
 import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.NotificationStatus._
 import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.{Notification, NotificationId, NotificationStatus}
 import uk.gov.hmrc.pushpullnotificationsapi.support.MongoApp
@@ -48,7 +48,7 @@ class NotificationRepositoryISpec extends UnitSpec with MongoApp with GuiceOneAp
 
     "save a Notification" in {
       val notification = Notification(NotificationId(UUID.randomUUID()), topicId,
-        notificationContentType = APPLICATION_JSON,
+        messageContentType = APPLICATION_JSON,
         message = "{\"someJsone\": \"someValue\"}",
         status = RECEIVED)
       val result: Unit = await(repo.saveNotification(notification))
@@ -59,7 +59,7 @@ class NotificationRepositoryISpec extends UnitSpec with MongoApp with GuiceOneAp
 
     "not save duplicate Notifications" in {
       val notification = Notification(NotificationId(UUID.randomUUID()), topicId = topicId,
-        notificationContentType = APPLICATION_JSON,
+        messageContentType = APPLICATION_JSON,
         message = "{",
         status = RECEIVED)
 


### PR DESCRIPTION
…removed redundant enum values, change content type so it is still an Enum but stored and returned as a string. Removed an untestable auth connector branch in the code. removed Either from notification service logic.