### PR TITLE
API-4546: add field encryption on secrets and notification payloads

### DIFF
--- a/app/uk/gov/hmrc/pushpullnotificationsapi/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/config/AppConfig.scala
@@ -38,6 +38,7 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   val apiStatus = config.get[String]("apiStatus")
   val authorizationToken: String = config.get[String]("authorizationKey")
+  val mongoEncryptionKey: String = config.get[String]("mongodb.encryption.key")
 
   val signPushNotifications: Boolean = config.getOptional[Boolean]("signPushNotifications").getOrElse(false)
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/config/ConfigurationProviders.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/config/ConfigurationProviders.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.pushpullnotificationsapi.config
 
-import java.util.concurrent.TimeUnit.{MINUTES, SECONDS}
+import java.util.concurrent.TimeUnit.{HOURS, MINUTES, SECONDS}
 
 import javax.inject.{Inject, Provider, Singleton}
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.pushpullnotificationsapi.scheduled.RetryPushNotificationsJobConfig
+import uk.gov.hmrc.crypto.CompositeSymmetricCrypto
+import uk.gov.hmrc.pushpullnotificationsapi.scheduled.{EncryptFieldsJobConfig, RetryPushNotificationsJobConfig}
+import uk.gov.hmrc.pushpullnotificationsapi.services.LocalCrypto
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -29,7 +31,9 @@ class ConfigurationModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
     Seq(
-      bind[RetryPushNotificationsJobConfig].toProvider[RetryPushNotificationsJobConfigProvider]
+      bind[CompositeSymmetricCrypto].to[LocalCrypto],
+      bind[RetryPushNotificationsJobConfig].toProvider[RetryPushNotificationsJobConfigProvider],
+      bind[EncryptFieldsJobConfig].toProvider[EncryptFieldsJobConfigProvider]
     )
   }
 }
@@ -48,5 +52,21 @@ class RetryPushNotificationsJobConfigProvider  @Inject()(configuration: Configur
     val numberOfHoursToRetry = configuration.getOptional[Int]("retryPushNotificationsJob.numberOfHoursToRetry").getOrElse(6)
     val parallelism = configuration.getOptional[Int]("retryPushNotificationsJob.parallelism").getOrElse(10)
     RetryPushNotificationsJobConfig(initialDelay, interval, enabled, numberOfHoursToRetry, parallelism)
+  }
+}
+
+@Singleton
+class EncryptFieldsJobConfigProvider  @Inject()(configuration: Configuration)
+  extends Provider[EncryptFieldsJobConfig] {
+
+  override def get(): EncryptFieldsJobConfig = {
+    // scalastyle:off magic.number
+    val initialDelay = configuration.getOptional[String]("encryptFieldsJob.initialDelay").map(Duration.create(_).asInstanceOf[FiniteDuration])
+      .getOrElse(FiniteDuration(120, SECONDS))
+    val interval = configuration.getOptional[String]("encryptFieldsJob.interval").map(Duration.create(_).asInstanceOf[FiniteDuration])
+      .getOrElse(FiniteDuration(24, HOURS))
+    val enabled = configuration.getOptional[Boolean]("encryptFieldsJob.enabled").getOrElse(false)
+    val parallelism = configuration.getOptional[Int]("encryptFieldsJob.parallelism").getOrElse(10)
+    EncryptFieldsJobConfig(initialDelay, interval, enabled, parallelism)
   }
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/config/Scheduler.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/config/Scheduler.scala
@@ -21,7 +21,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.Application
 import play.api.inject.ApplicationLifecycle
 import uk.gov.hmrc.play.scheduling.{RunningOfScheduledJobs, ScheduledJob}
-import uk.gov.hmrc.pushpullnotificationsapi.scheduled.RetryPushNotificationsJob
+import uk.gov.hmrc.pushpullnotificationsapi.scheduled.{EncryptFieldsJob, RetryPushNotificationsJob}
 
 import scala.concurrent.ExecutionContext
 
@@ -33,8 +33,9 @@ class SchedulerModule extends AbstractModule {
 
 @Singleton
 class Scheduler @Inject()(retryPushNotificationsJob: RetryPushNotificationsJob,
+                          encryptFieldsJob: EncryptFieldsJob,
                           override val applicationLifecycle: ApplicationLifecycle,
                           override val application: Application)
                          (implicit val ec: ExecutionContext) extends RunningOfScheduledJobs {
-  override lazy val scheduledJobs: Seq[ScheduledJob] = Seq(retryPushNotificationsJob).filter(_.isEnabled)
+  override lazy val scheduledJobs: Seq[ScheduledJob] = Seq(retryPushNotificationsJob, encryptFieldsJob).filter(_.isEnabled)
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/controllers/NotificationsController.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/controllers/NotificationsController.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.pushpullnotificationsapi.controllers
 import java.util.UUID
 
 import javax.inject.{Inject, Singleton}
-import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
 import play.mvc.Http.MimeTypes
@@ -34,7 +33,6 @@ import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.{MessageContent
 import uk.gov.hmrc.pushpullnotificationsapi.services.NotificationsService
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.control.NonFatal
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 import scala.xml.NodeSeq

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/models/jsonformatters.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/models/jsonformatters.scala
@@ -18,30 +18,8 @@ package uk.gov.hmrc.pushpullnotificationsapi.models
 
 import org.joda.time.DateTime
 import play.api.libs.json._
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.play.json.Union
 import uk.gov.hmrc.pushpullnotificationsapi.models.notifications._
-
-
-object ReactiveMongoFormatters {
-  implicit val clientIdFormatter: Format[ClientId] = Json.valueFormat[ClientId]
-  implicit val boxIdFormatter: Format[BoxId] = Json.valueFormat[BoxId]
-
-  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
-  implicit val pullSubscriberFormats: OFormat[PullSubscriber] = Json.format[PullSubscriber]
-  implicit val pushSubscriberFormats: OFormat[PushSubscriber] = Json.format[PushSubscriber]
-  implicit val formatBoxCreator: Format[BoxCreator] = Json.format[BoxCreator]
-  implicit val formatSubscriber: Format[Subscriber] = Union.from[Subscriber]("subscriptionType")
-    .and[PullSubscriber](SubscriptionType.API_PULL_SUBSCRIBER.toString)
-    .and[PushSubscriber](SubscriptionType.API_PUSH_SUBSCRIBER.toString)
-    .format
-  implicit val boxFormats: OFormat[Box] = Json.format[Box]
-  implicit val clientSecretFormats: OFormat[ClientSecret] = Json.format[ClientSecret]
-  implicit val clientFormats: OFormat[Client] = Json.format[Client]
-  implicit val notificationIdFormatter: Format[NotificationId] = Json.valueFormat[NotificationId]
-  implicit val notificationsFormats: OFormat[Notification] =Json.format[Notification]
-  implicit val retryableNotificationFormat: OFormat[RetryableNotification] = Json.format[RetryableNotification]
-}
 
 object ResponseFormatters{
   val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/BoxRepository.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/BoxRepository.scala
@@ -25,8 +25,8 @@ import reactivemongo.api.commands.WriteResult
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
-import uk.gov.hmrc.pushpullnotificationsapi.models.ReactiveMongoFormatters._
 import uk.gov.hmrc.pushpullnotificationsapi.models._
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.ReactiveMongoFormatters._
 import uk.gov.hmrc.pushpullnotificationsapi.util.mongo.IndexHelper.{createAscendingIndex, createSingleFieldAscendingIndex}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,7 +36,7 @@ class BoxRepository @Inject()(mongoComponent: ReactiveMongoComponent)
   extends ReactiveRepository[Box, BSONObjectID](
     "box",
     mongoComponent.mongoConnector.db,
-    ReactiveMongoFormatters.boxFormats,
+    boxFormats,
     ReactiveMongoFormats.objectIdFormats) {
 
   implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
@@ -75,4 +75,3 @@ class BoxRepository @Inject()(mongoComponent: ReactiveMongoComponent)
       _.result[Box]
     }
 }
-

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/ClientRepository.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/ClientRepository.scala
@@ -16,23 +16,33 @@
 
 package uk.gov.hmrc.pushpullnotificationsapi.repository
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
 import javax.inject.{Inject, Singleton}
+import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.akkastream.cursorProducer
 import reactivemongo.bson.BSONObjectID
+import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
+import uk.gov.hmrc.crypto.CompositeSymmetricCrypto
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
-import uk.gov.hmrc.pushpullnotificationsapi.models.ReactiveMongoFormatters.clientFormats
 import uk.gov.hmrc.pushpullnotificationsapi.models._
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.DbClient
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.DbClient.{fromClient, toClient}
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.DbClientSecret.fromClientSecret
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.ReactiveMongoFormatters.{dbClientFormatter, dbClientSecretFormatter}
 import uk.gov.hmrc.pushpullnotificationsapi.util.mongo.IndexHelper.createSingleFieldAscendingIndex
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ClientRepository @Inject()(mongoComponent: ReactiveMongoComponent)(implicit ec: ExecutionContext)
-  extends ReactiveRepository[Client, BSONObjectID](
+class ClientRepository @Inject()(mongoComponent: ReactiveMongoComponent, crypto: CompositeSymmetricCrypto)
+                                (implicit ec: ExecutionContext, val mat: Materializer)
+  extends ReactiveRepository[DbClient, BSONObjectID](
     "client",
     mongoComponent.mongoConnector.db,
-    ReactiveMongoFormatters.clientFormats,
+    dbClientFormatter,
     ReactiveMongoFormats.objectIdFormats) {
 
   override def indexes = Seq(
@@ -40,10 +50,24 @@ class ClientRepository @Inject()(mongoComponent: ReactiveMongoComponent)(implici
   )
 
   def insertClient(client: Client): Future[Client] = {
-    collection.insert.one(client).map(_ => client)
+    collection.insert.one(fromClient(client, crypto)).map(_ => client)
   }
 
   def findByClientId(id: ClientId): Future[Option[Client]] = {
-    find("id" -> id.value).map(_.headOption)
+    find("id" -> id.value).map(_.headOption.map(toClient(_, crypto)))
+  }
+
+  @deprecated("delete after scheduled job encryts the existing client secrets")
+  def encryptClientSecrets(parallelism: Int): Future[Unit] = {
+    def updateSecrets(client: Client) = {
+      val encryptedSecrets = Json.toJson(client.secrets.map(fromClientSecret(_, crypto)))
+      val updateStatement = Json.obj("$set" -> Json.obj("secrets" -> encryptedSecrets))
+      findAndUpdate(Json.obj("id" -> client.id.value), updateStatement, fetchNewObject = false).map(_ => ())
+    }
+
+    collection.find(Json.obj(), Option.empty[DbClient]).cursor[DbClient]()
+      .documentSource()
+      .map(toClient(_, crypto))
+      .runWith(Sink.foreachAsync(parallelism)(updateSecrets)).map(_ => ())
   }
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/models/DbClient.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/models/DbClient.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushpullnotificationsapi.repository.models
+
+import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, Crypted, PlainText}
+import uk.gov.hmrc.pushpullnotificationsapi.models.{Client, ClientId, ClientSecret}
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.DbClientSecret.{fromClientSecret, toClientSecret}
+
+
+
+private[repository] case class DbClient(id: ClientId, secrets: Seq[DbClientSecret])
+private[repository] object DbClient {
+  def fromClient(client: Client, crypto: CompositeSymmetricCrypto): DbClient = {
+    DbClient(client.id, client.secrets.map(fromClientSecret(_, crypto)))
+  }
+
+  def toClient(dbClient: DbClient, crypto: CompositeSymmetricCrypto): Client = {
+    Client(dbClient.id, dbClient.secrets.map(toClientSecret(_, crypto)))
+  }
+}
+
+private[repository] case class DbClientSecret(value: String, encryptedValue: Option[String])
+private[repository] object DbClientSecret {
+  def fromClientSecret(clientSecret: ClientSecret, crypto: CompositeSymmetricCrypto): DbClientSecret = {
+    DbClientSecret(clientSecret.value, Some(crypto.encrypt(PlainText(clientSecret.value)).value))
+  }
+
+  def toClientSecret(dbClientSecret: DbClientSecret, crypto: CompositeSymmetricCrypto): ClientSecret = {
+    dbClientSecret.encryptedValue match {
+      case Some(encryptedSecret) => ClientSecret(crypto.decrypt(Crypted(encryptedSecret)).value)
+      case _ => ClientSecret(dbClientSecret.value)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/models/DbNotification.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/models/DbNotification.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushpullnotificationsapi.repository.models
+
+import org.joda.time.{DateTime, DateTimeZone}
+import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, Crypted, PlainText}
+import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.NotificationStatus.PENDING
+import uk.gov.hmrc.pushpullnotificationsapi.models.notifications._
+import uk.gov.hmrc.pushpullnotificationsapi.models.{Box, BoxId}
+import uk.gov.hmrc.pushpullnotificationsapi.repository.models.DbNotification.{fromNotification, toNotification}
+
+private[repository] case class DbNotification(notificationId: NotificationId,
+                                              boxId: BoxId,
+                                              messageContentType: MessageContentType,
+                                              message: String,
+                                              encryptedMessage: Option[String],
+                                              status: NotificationStatus = PENDING,
+                                              createdDateTime: DateTime = DateTime.now(DateTimeZone.UTC),
+                                              readDateTime: Option[DateTime] = None,
+                                              pushedDateTime: Option[DateTime] = None,
+                                              retryAfterDateTime: Option[DateTime] = None)
+
+private[repository] object DbNotification {
+  def fromNotification(notification: Notification, crypto: CompositeSymmetricCrypto): DbNotification = {
+    DbNotification(
+      notification.notificationId,
+      notification.boxId,
+      notification.messageContentType,
+      notification.message,
+      Some(crypto.encrypt(PlainText(notification.message)).value),
+      notification.status,
+      notification.createdDateTime,
+      notification.readDateTime,
+      notification.pushedDateTime,
+      notification.retryAfterDateTime
+    )
+  }
+
+  def toNotification(dbNotification: DbNotification, crypto: CompositeSymmetricCrypto): Notification = {
+    val message = dbNotification.encryptedMessage match {
+      case Some(encryptedMessage) => crypto.decrypt(Crypted(encryptedMessage)).value
+      case _ => dbNotification.message
+    }
+
+    Notification(
+      dbNotification.notificationId,
+      dbNotification.boxId,
+      dbNotification.messageContentType,
+      message,
+      dbNotification.status,
+      dbNotification.createdDateTime,
+      dbNotification.readDateTime,
+      dbNotification.pushedDateTime,
+      dbNotification.retryAfterDateTime
+    )
+  }
+}
+
+private[repository] case class DbRetryableNotification(notification: DbNotification, box: Box)
+
+private[repository] object DbRetryableNotification {
+  def fromRetryableNotification(retryableNotification: RetryableNotification, crypto: CompositeSymmetricCrypto): DbRetryableNotification = {
+    DbRetryableNotification(fromNotification(retryableNotification.notification, crypto), retryableNotification.box)
+  }
+
+  def toRetryableNotification(dbRetryableNotification: DbRetryableNotification, crypto: CompositeSymmetricCrypto): RetryableNotification = {
+    RetryableNotification(toNotification(dbRetryableNotification.notification, crypto), dbRetryableNotification.box)
+  }
+}

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/repository/models/ReactiveMongoFormatters.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/repository/models/ReactiveMongoFormatters.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushpullnotificationsapi.repository.models
+
+import org.joda.time.DateTime
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import uk.gov.hmrc.play.json.Union
+import uk.gov.hmrc.pushpullnotificationsapi.models.notifications.NotificationId
+import uk.gov.hmrc.pushpullnotificationsapi.models._
+
+private[repository] object ReactiveMongoFormatters {
+  implicit val clientIdFormatter: Format[ClientId] = Json.valueFormat[ClientId]
+  implicit val boxIdFormatter: Format[BoxId] = Json.valueFormat[BoxId]
+
+  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
+  implicit val pullSubscriberFormats: OFormat[PullSubscriber] = Json.format[PullSubscriber]
+  implicit val pushSubscriberFormats: OFormat[PushSubscriber] = Json.format[PushSubscriber]
+  implicit val formatBoxCreator: Format[BoxCreator] = Json.format[BoxCreator]
+  implicit val formatSubscriber: Format[Subscriber] = Union.from[Subscriber]("subscriptionType")
+    .and[PullSubscriber](SubscriptionType.API_PULL_SUBSCRIBER.toString)
+    .and[PushSubscriber](SubscriptionType.API_PUSH_SUBSCRIBER.toString)
+    .format
+  implicit val boxFormats: OFormat[Box] = Json.format[Box]
+  implicit val notificationIdFormatter: Format[NotificationId] = Json.valueFormat[NotificationId]
+
+  implicit val dbClientSecretFormatter: OFormat[DbClientSecret] = Json.format[DbClientSecret]
+  implicit val dbClientFormatter: OFormat[DbClient] = Json.format[DbClient]
+  implicit val dbNotificationFormatter: OFormat[DbNotification] = Json.format[DbNotification]
+  implicit val dbRetryableNotificationFormatter: OFormat[DbRetryableNotification] = Json.format[DbRetryableNotification]
+}

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/scheduled/EncryptFieldsJob.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/scheduled/EncryptFieldsJob.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushpullnotificationsapi.scheduled
+
+import akka.stream.Materializer
+import com.google.inject.Singleton
+import javax.inject.Inject
+import org.joda.time.Duration
+import play.api.Logger
+import play.modules.reactivemongo.ReactiveMongoComponent
+import uk.gov.hmrc.lock.{LockKeeper, LockRepository}
+import uk.gov.hmrc.pushpullnotificationsapi.repository.{ClientRepository, NotificationsRepository}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+@Singleton
+@deprecated("delete after it has encryted the existing data")
+class EncryptFieldsJob @Inject()(override val lockKeeper: EncryptFieldsJobLockKeeper,
+                                          jobConfig: EncryptFieldsJobConfig,
+                                          notificationsRepository: NotificationsRepository,
+                                          clientRepository: ClientRepository)
+                                         (implicit mat: Materializer) extends ScheduledMongoJob {
+
+  override def name: String = "EncryptFieldsJob"
+  override def interval: FiniteDuration = jobConfig.interval
+  override def initialDelay: FiniteDuration = jobConfig.initialDelay
+  override val isEnabled: Boolean = jobConfig.enabled
+
+  override def runJob(implicit ec: ExecutionContext): Future[RunningOfJobSuccessful] = {
+    (for {
+      _ <- clientRepository.encryptClientSecrets(jobConfig.parallelism)
+      _ <- notificationsRepository.encryptNotificationMessages(jobConfig.parallelism)
+    } yield RunningOfJobSuccessful).recoverWith {
+      case NonFatal(e) =>
+        Logger.error("Failed to encrypt fields", e)
+        Future.failed(RunningOfJobFailed(name, e))
+    }
+  }
+}
+
+class EncryptFieldsJobLockKeeper @Inject()(mongo: ReactiveMongoComponent) extends LockKeeper {
+  override def repo: LockRepository = new LockRepository()(mongo.mongoConnector.db)
+
+  override def lockId: String = "EncryptFieldsJob"
+
+  override val forceLockReleaseAfter: Duration = Duration.standardMinutes(60) // scalastyle:off magic.number
+}
+
+case class EncryptFieldsJobConfig(initialDelay: FiniteDuration, interval: FiniteDuration, enabled: Boolean, parallelism: Int)

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/services/LocalCrypto.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/services/LocalCrypto.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushpullnotificationsapi.services
+
+import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.crypto.{AesCrypto, CompositeSymmetricCrypto, Decrypter}
+import uk.gov.hmrc.pushpullnotificationsapi.config.AppConfig
+
+@Singleton
+class LocalCrypto @Inject()(appConfig: AppConfig) extends CompositeSymmetricCrypto {
+
+  override protected lazy val currentCrypto: AesCrypto = new AesCrypto {
+    override protected lazy val encryptionKey: String = appConfig.mongoEncryptionKey
+  }
+
+  override protected val previousCryptos = Seq.empty[Decrypter]
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val scoverageSettings = {
 lazy val compileDeps = Seq(
   ws,
   "uk.gov.hmrc" %% "bootstrap-play-26" % "1.13.0",
+  "uk.gov.hmrc" %% "crypto" % "5.6.0",
   "uk.gov.hmrc" %% "auth-client" % "3.0.0-play-26",
   "com.beachape" %% "enumeratum-play-json" % "1.6.0",
   "uk.gov.hmrc" %% "play-json-union-formatter" % "1.11.0",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -174,5 +174,4 @@ microservice {
 }
 
 authorizationKey = "pnonzaHB1bGxhcGkTTT="
-
-
+mongodb.encryption.key = "YjQ+NiViNGY4V2l2cSxnCg=="

--- a/it/uk/gov/hmrc/pushpullnotificationsapi/controllers/ClientControllerISpec.scala
+++ b/it/uk/gov/hmrc/pushpullnotificationsapi/controllers/ClientControllerISpec.scala
@@ -52,7 +52,7 @@ class ClientControllerISpec extends ServerBaseISpec with BeforeAndAfterEach with
 
   "GET /client/:clientId/secrets" should {
     "respond with 200 and the array of secrets for the requested client" in {
-      await(repo.insert(client))
+      await(repo.insertClient(client))
 
       val result = doGet(s"/client/${clientId.value}/secrets", List("Authorization" -> authToken))
 
@@ -61,7 +61,7 @@ class ClientControllerISpec extends ServerBaseISpec with BeforeAndAfterEach with
     }
 
     "respond with 404 when there is no matching client for the given client ID" in {
-      await(repo.insert(client))
+      await(repo.insertClient(client))
 
       val result = doGet(s"/client/wrongClientId/secrets", List("Authorization" -> authToken))
 
@@ -70,7 +70,7 @@ class ClientControllerISpec extends ServerBaseISpec with BeforeAndAfterEach with
     }
 
     "respond with 403 when the authorization header does not match the token from the app config" in {
-      await(repo.insert(client))
+      await(repo.insertClient(client))
 
       val result = doGet(s"/client/${clientId.value}/secrets", List("Authorization" -> "wrongToken"))
 

--- a/it/uk/gov/hmrc/pushpullnotificationsapi/controllers/NotificationsControllerISpec.scala
+++ b/it/uk/gov/hmrc/pushpullnotificationsapi/controllers/NotificationsControllerISpec.scala
@@ -124,7 +124,7 @@ class NotificationsControllerISpec extends ServerBaseISpec with BeforeAndAfterEa
   }
 
   def createNotifications(boxId: BoxId, numberToCreate: Int): List[String] = {
-    var notifications: mutable.MutableList[String] = mutable.MutableList[String]()
+    val notifications: mutable.MutableList[String] = mutable.MutableList[String]()
     for (_ <- 0 until numberToCreate) {
       val result = doPost(s"$url/box/${boxId.raw}/notifications", "{}", validHeadersJson)
       result.status shouldBe CREATED

--- a/test/uk/gov/hmrc/pushpullnotificationsapi/controllers/BoxControllerSpec.scala
+++ b/test/uk/gov/hmrc/pushpullnotificationsapi/controllers/BoxControllerSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
+import play.api.http.HeaderNames.{CONTENT_TYPE, USER_AGENT}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
@@ -33,10 +34,9 @@ import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.pushpullnotificationsapi.config.AppConfig
 import uk.gov.hmrc.pushpullnotificationsapi.controllers.actionbuilders.AuthAction
-import uk.gov.hmrc.pushpullnotificationsapi.models.ReactiveMongoFormatters._
+import uk.gov.hmrc.pushpullnotificationsapi.models.ResponseFormatters.boxFormats
 import uk.gov.hmrc.pushpullnotificationsapi.models._
 import uk.gov.hmrc.pushpullnotificationsapi.services.BoxService
-import play.api.http.HeaderNames.{CONTENT_TYPE, USER_AGENT}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/test/uk/gov/hmrc/pushpullnotificationsapi/scheduled/EncryptFieldsJobSpec.scala
+++ b/test/uk/gov/hmrc/pushpullnotificationsapi/scheduled/EncryptFieldsJobSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushpullnotificationsapi.scheduled
+
+import java.util.concurrent.TimeUnit.{HOURS, SECONDS}
+
+import akka.stream.Materializer
+import org.joda.time.Duration
+import org.mockito.Mockito.{never, times, verify, when}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.modules.reactivemongo.ReactiveMongoComponent
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.lock.LockRepository
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.pushpullnotificationsapi.repository.{ClientRepository, NotificationsRepository}
+
+import scala.concurrent.Future.{failed, successful}
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+class EncryptFieldsJobSpec extends UnitSpec with MockitoSugar with MongoSpecSupport with GuiceOneAppPerSuite {
+
+  implicit override lazy val app: Application = new GuiceApplicationBuilder()
+    .disable[com.kenshoo.play.metrics.PlayModule]
+    .configure("metrics.enabled" -> false).build()
+  implicit lazy val materializer: Materializer = app.materializer
+
+  trait Setup {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val lockKeeperSuccess: () => Boolean = () => true
+    private val reactiveMongoComponent = new ReactiveMongoComponent {
+      override def mongoConnector: MongoConnector = mongoConnectorForTest
+    }
+    val mockLockKeeper: EncryptFieldsJobLockKeeper = new EncryptFieldsJobLockKeeper(reactiveMongoComponent) {
+      override def lockId: String = "testLock"
+      override def repo: LockRepository = mock[LockRepository]
+      override val forceLockReleaseAfter: Duration = Duration.standardMinutes(5) // scalastyle:off magic.number
+      override def tryLock[T](body: => Future[T])(implicit ec: ExecutionContext): Future[Option[T]] =
+        if (lockKeeperSuccess()) body.map(value => successful(Some(value)))
+        else successful(None)
+    }
+
+    val encryptFieldsJobConfig: EncryptFieldsJobConfig = EncryptFieldsJobConfig(
+      FiniteDuration(60, SECONDS), FiniteDuration(24, HOURS), enabled = true, parallelism = 2)
+    val mockNotificationsRepository: NotificationsRepository = mock[NotificationsRepository]
+    val mockClientRepository: ClientRepository = mock[ClientRepository]
+    val underTest = new EncryptFieldsJob(
+      mockLockKeeper,
+      encryptFieldsJobConfig,
+      mockNotificationsRepository,
+      mockClientRepository
+    )
+  }
+
+  "EncryptFieldsJob" should {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    "encrypt client secrets and notification messages" in new Setup {
+      when(mockNotificationsRepository.encryptNotificationMessages(encryptFieldsJobConfig.parallelism)).thenReturn(successful(()))
+      when(mockClientRepository.encryptClientSecrets(encryptFieldsJobConfig.parallelism)).thenReturn(successful(()))
+
+      val result: underTest.Result = await(underTest.execute)
+
+      verify(mockNotificationsRepository, times(1)).encryptNotificationMessages(encryptFieldsJobConfig.parallelism)
+      verify(mockClientRepository, times(1)).encryptClientSecrets(encryptFieldsJobConfig.parallelism)
+      result.message shouldBe "EncryptFieldsJob Job ran successfully."
+    }
+
+    "not execute if the job is already running" in new Setup {
+      override val lockKeeperSuccess: () => Boolean = () => false
+
+      val result: underTest.Result = await(underTest.execute)
+
+      verify(mockNotificationsRepository, never).encryptNotificationMessages(encryptFieldsJobConfig.parallelism)
+      verify(mockClientRepository, never).encryptClientSecrets(encryptFieldsJobConfig.parallelism)
+      result.message shouldBe "EncryptFieldsJob did not run because repository was locked by another instance of the scheduler."
+    }
+
+    "handle error when something fails" in new Setup {
+      when(mockClientRepository.encryptClientSecrets(encryptFieldsJobConfig.parallelism)).thenReturn(failed(new RuntimeException("Failed")))
+
+      val result: underTest.Result = await(underTest.execute)
+
+      result.message shouldBe "The execution of scheduled job EncryptFieldsJob failed with error 'Failed'. " +
+        "The next execution of the job will do retry."
+    }
+  }
+}


### PR DESCRIPTION
The field level encryption is encapsulated at the repository level. This is phase 1 where we encrypt the fields but the unencrypted fields are still present in case we need to roll back. If this works, we'll have another change that removes the unencrypted fields.