### PR TITLE
APIS-5113 - Remove "signPushNotifications" feature flag from PPNS

### DIFF
--- a/app/uk/gov/hmrc/pushpullnotificationsapi/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/config/AppConfig.scala
@@ -42,6 +42,4 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   val apiStatus = config.get[String]("apiStatus")
   val authorizationToken: String = config.get[String]("authorizationKey")
   val mongoEncryptionKey: String = config.get[String]("mongodb.encryption.key")
-
-  val signPushNotifications: Boolean = config.getOptional[Boolean]("signPushNotifications").getOrElse(false)
 }

--- a/app/uk/gov/hmrc/pushpullnotificationsapi/services/NotificationPushService.scala
+++ b/app/uk/gov/hmrc/pushpullnotificationsapi/services/NotificationPushService.scala
@@ -71,11 +71,7 @@ class NotificationPushService @Inject()(connector: PushConnector,
     subscriber.subscriptionType.equals(API_PUSH_SUBSCRIBER) && (!subscriber.asInstanceOf[PushSubscriber].callBackUrl.isEmpty)
 
   private def calculateForwardedHeaders(client: Client, notificationAsJsonString: String): List[ForwardedHeader] = {
-    if (appConfig.signPushNotifications) {
-      val payloadSignature = hmacService.sign(client.secrets.head.value, notificationAsJsonString)
-      List(ForwardedHeader("X-Hub-Signature", payloadSignature))
-    } else {
-      List.empty
-    }
+    val payloadSignature = hmacService.sign(client.secrets.head.value, notificationAsJsonString)
+    List(ForwardedHeader("X-Hub-Signature", payloadSignature))
   }
 }


### PR DESCRIPTION
 - It now always adds the 'X-Hub-Signature' signature header.